### PR TITLE
Remove explicit activesupport dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'net'
-gem 'activesupport', '~>4.2'
 gem 'builder', '~> 3.0'
 
 group :test do

--- a/poesie.gemspec
+++ b/poesie.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.executables << 'poesie'
 
   s.add_dependency 'net', '~> 0.3'
-  s.add_dependency 'activesupport', '~>4.2'
   s.add_dependency 'builder', '~> 3.0'
 end


### PR DESCRIPTION
Due to explicit requirement for specific activesupport version Poesie is not compatible with other updated gems using activesupport.

We noticed this when trying to use new CocoaPods, which are very probable tool used with Poesie for iOS developers.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    cocoapods (= 1.10.0.rc.1) was resolved to 1.10.0.rc.1, which depends on
cocoapods-core (= 1.10.0.rc.1) was resolved to 1.10.0.rc.1, which depends
on
        activesupport (> 5.0, < 6)

    fastlane-plugin-poesie was resolved to 0.4.0, which depends on
      poesie (~> 1.5.1) was resolved to 1.5.1, which depends on
        activesupport (~> 4.2)
```

Since activesupport is not a direct dependency for Poesie, I decided to remove it from .gemspec to make it more compatible.

### Test results

```
Poesie::AndroidFormatter
  generates proper strings.xml file
  generates proper strings.xml file with date
  generates proper strings.xml file with substitutions

Poesie::AppleFormatter
  Localizable.strings
    generates proper strings file
    generates proper strings file with date
    generates proper strings file with substitutions
  Localizable.stringsdict
    generates proper stringsdict file
    generates proper stringsdict file with date
    generates proper stringsdict file with substitutions

Poesie::ContextFormatter
  Context.json
    generates proper context json file
    generates proper context json file, filtering keys

Finished in 0.04183 seconds (files took 0.11713 seconds to load)
11 examples, 0 failures
```