### PR TITLE
Add support to optional --tags parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Usage: poesie [options]
     -c, --context PATH               Path of the *.json file to generate for contexts
     -d, --date                       Generate the current date in file headers
     -s, --subst FILE                 Path to a YAML file listing all text substitutions
+    -g, --tags TAGS                  Comma separated list of tags used to filter extracted terms
     -h, --help                       Show this message
     -v, --version                    Show version
 ```

--- a/bin/poesie
+++ b/bin/poesie
@@ -25,7 +25,8 @@ options = {
     :strings_xml => nil,
     :context_file => nil,
     :print_date => false,
-    :substitutions => nil
+    :substitutions => nil,
+    :tags => nil
 }
 
 opts = OptionParser.new do |opts|
@@ -63,6 +64,9 @@ opts = OptionParser.new do |opts|
     Poesie.exit_with_error("The provided substitutions file #{path} should only contain a (Array of) Hashes with String keys and values") unless valid
     options[:substitutions] = subst
   end
+  opts.on('-g TAGS', '--tags TAGS', %q(Comma separated list of tags used to filter exported terms)) do |tags|
+    options[:tags] = tags
+  end
   opts.on_tail('-h', '--help', %q(Show this message)) { puts opts; exit 1 }
   opts.on_tail('-v', '--version', 'Show version') { puts Poesie::VERSION; exit }
 end
@@ -81,7 +85,7 @@ Poesie.exit_with_error('You need to specify your POEditor project identifier usi
 exporter = Poesie::Exporter.new(options[:api_token], options[:project_id])
 Poesie.exit_with_error('You need to specify your POEditor project language using --lang option (see --help for more info)') if options[:lang].nil?
 
-exporter.run(options[:lang]) do |terms|
+exporter.run(options[:lang], options[:tags]) do |terms|
   Poesie::Log::title("== Language #{options[:lang]} ==")
 
   # iOS

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'pp'
 
 module Poesie
   class Exporter
@@ -21,9 +22,9 @@ module Poesie
     #        The action to do with the exported terms
     #        Typically call one of AppleFormatter::… or AndroidFormatter::… methods here
     #
-    def run(lang)
+    def run(lang, tags)
         Log::info(' - Generating export...')
-        uri = generate_export_uri(lang)
+        uri = generate_export_uri(lang, tags)
         Log::info(' - Downloading exported file...')
         json_string = Net::HTTP.get(URI(uri))
         json = JSON.parse(json_string)
@@ -40,9 +41,10 @@ module Poesie
     #        Language code, like 'fr', 'en', etc
     # @return [String] URL of the exported file ready to be downloaded
     #
-    def generate_export_uri(lang)
+    def generate_export_uri(lang, tags)
       uri = URI('https://api.poeditor.com/v2/projects/export')
-      res = Net::HTTP.post_form(uri, 'api_token' => @api_token, 'id' => @project_id, 'type' => 'json', 'language' => lang)
+      tags_safe = tags.nil? ? [] : tags.split(',')
+      res = Net::HTTP.post_form(uri, 'api_token' => @api_token, 'id' => @project_id, 'type' => 'json', 'language' => lang, 'tags' => tags_safe)
       json = JSON.parse(res.body)
       unless json['response']['status'] == 'success'
         r = json['response']


### PR DESCRIPTION
Poeditor allows setting tags to the terms and filtering downloaded strings based on that information. I have added new parameter -g/--tags (-t is already reserved for the API token ) to allow this filtering.

You can provide multiple comma-separated tags. export API then returns only terms labeled by all the tags.