### PR TITLE
[func] replace .exists deprecated API with .exist

### DIFF
--- a/bin/poesie
+++ b/bin/poesie
@@ -52,7 +52,7 @@ opts = OptionParser.new do |opts|
     options[:print_date] = true
   end
   opts.on('-s FILE', '--subst FILE', %q(Path to a YAML file listing all substitutions)) do |path|
-    Poesie.exit_with_error("The substitutions file #{path} was not found") unless File.exists?(path)
+    Poesie.exit_with_error("The substitutions file #{path} was not found") unless File.exist?(path)
     begin
       subst = YAML.load_file(path)
     rescue Psych::SyntaxError => e


### PR DESCRIPTION
Change deprecated API to be able to execute `poesie` with substitutions in ruby 3>.

![Screenshot 2024-01-29 at 17 28 52](https://github.com/NijiDigital/poesie/assets/140385033/50ef9e8d-ed55-4956-be1c-cc61c7bafacb)

We experience this error in ruby 3.2.2.