### PR TITLE
Add --unsorted option to Retain Original Term Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Usage: poesie [options]
     -c, --context PATH               Path of the *.json file to generate for contexts
     -d, --date                       Generate the current date in file headers
     -s, --subst FILE                 Path to a YAML file listing all text substitutions
+    -u, --unsorted                   Disable alphabetical sorting of exported terms
     -h, --help                       Show this message
     -v, --version                    Show version
 ```

--- a/bin/poesie
+++ b/bin/poesie
@@ -63,6 +63,9 @@ opts = OptionParser.new do |opts|
     Poesie.exit_with_error("The provided substitutions file #{path} should only contain a (Array of) Hashes with String keys and values") unless valid
     options[:substitutions] = subst
   end
+  opts.on('-u', '--unsorted', %q(Disable alphabetical sorting of exported terms)) do
+    options[:unsorted] = true
+  end
   opts.on_tail('-h', '--help', %q(Show this message)) { puts opts; exit 1 }
   opts.on_tail('-v', '--version', 'Show version') { puts Poesie::VERSION; exit }
 end
@@ -81,7 +84,7 @@ Poesie.exit_with_error('You need to specify your POEditor project identifier usi
 exporter = Poesie::Exporter.new(options[:api_token], options[:project_id])
 Poesie.exit_with_error('You need to specify your POEditor project language using --lang option (see --help for more info)') if options[:lang].nil?
 
-exporter.run(options[:lang]) do |terms|
+exporter.run(options[:lang], sort_terms: !options[:unsorted]) do |terms|
   Poesie::Log::title("== Language #{options[:lang]} ==")
 
   # iOS

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -21,13 +21,13 @@ module Poesie
     #        The action to do with the exported terms
     #        Typically call one of AppleFormatter::… or AndroidFormatter::… methods here
     #
-    def run(lang)
+    def run(lang, sort_terms: true)
         Log::info(' - Generating export...')
         uri = generate_export_uri(lang)
         Log::info(' - Downloading exported file...')
         json_string = Net::HTTP.get(URI(uri))
         json = JSON.parse(json_string)
-        terms = json.sort { |item1, item2| item1['term'] <=> item2['term'] }
+        terms = sort_terms ? json.sort { |item1, item2| item1['term'] <=> item2['term'] } : json
         if block_given?
           Log::info(' - Processing generated strings...')
           yield terms


### PR DESCRIPTION
There are valid cases where users may want to preserve the original order of terms as returned by the POEditor API. Currently poesie does not provide an option to retain this default behavior.

This PR introduces an optional `-u`/`--unsorted` flag that allows users to skip sorting the exported terms before saving them. By default, terms will continue to be sorted to maintain backward compatibility.